### PR TITLE
Android Chat Fix

### DIFF
--- a/eaglermobile.user.js
+++ b/eaglermobile.user.js
@@ -6,7 +6,7 @@
 // @downloadURL     https://raw.githubusercontent.com/FlamedDogo99/EaglerMobile/main/eaglermobile.user.js
 // @license         Apache License 2.0 - http://www.apache.org/licenses/
 // @match           https://eaglercraft.com/mc/*
-// @version         3.0.5-chat-fix
+// @version         3.0.6-chat-fix
 // @updateURL       https://raw.githubusercontent.com/FlamedDogo99/EaglerMobile/main/eaglermobile.user.js
 // @run-at          document-start
 // ==/UserScript==
@@ -375,7 +375,7 @@ function insertCanvasElements() {
     hiddenInput.style.cssText = "position:absolute;top: 0vh; margin: auto; left: 8vh; right:0vh; width: 8vh; height: 8vh;font-size:20px;z-index:-10;color: transparent;text-shadow: 0 0 0 black;";
     hiddenInput.value = " " //Allows delete to be detected before input is changed
     hiddenInput.addEventListener("input", function(e) {
-        let inputData = e.data ?? "delete"; // backspace makes null
+        let inputData = (e.data == null) ? "delete" : e.data.slice(-1); // backspace makes null
         window.lastKey = inputData
         hiddenInput.value = " "; // We need a character to detect deleting
         if(window.keyboardFix) {

--- a/eaglermobile.user.js
+++ b/eaglermobile.user.js
@@ -6,7 +6,7 @@
 // @downloadURL     https://raw.githubusercontent.com/FlamedDogo99/EaglerMobile/main/eaglermobile.user.js
 // @license         Apache License 2.0 - http://www.apache.org/licenses/
 // @match           https://eaglercraft.com/mc/*
-// @version         3.0.3-chat-fix
+// @version         3.0.4-chat-fix
 // @updateURL       https://raw.githubusercontent.com/FlamedDogo99/EaglerMobile/main/eaglermobile.user.js
 // @run-at          document-start
 // ==/UserScript==

--- a/eaglermobile.user.js
+++ b/eaglermobile.user.js
@@ -372,7 +372,7 @@ function insertCanvasElements() {
     hiddenInput.id = "hiddenInput"
     hiddenInput.classList.add("inMenu")
     // We are hiding the text input behind button because opacity was causing problems.
-    hiddenInput.style.cssText = "position:absolute;top: 0vh; margin: auto; left: 8vh; right:0vh; width: 8vh; height: 8vh;font-size:20px;-index:-10;color: transparent;text-shadow: 0 0 0 black;";
+    hiddenInput.style.cssText = "position:absolute;top: 0vh; margin: auto; left: 8vh; right:0vh; width: 8vh; height: 8vh;font-size:20px;z-index:-10;color: transparent;text-shadow: 0 0 0 black;";
     hiddenInput.value = " " //Allows delete to be detected before input is changed
     hiddenInput.addEventListener("input", function(e) {
         let inputData = e.data ?? "delete"; // backspace makes null

--- a/eaglermobile.user.js
+++ b/eaglermobile.user.js
@@ -6,7 +6,7 @@
 // @downloadURL     https://raw.githubusercontent.com/FlamedDogo99/EaglerMobile/main/eaglermobile.user.js
 // @license         Apache License 2.0 - http://www.apache.org/licenses/
 // @match           https://eaglercraft.com/mc/*
-// @version         3.0.4-chat-fix
+// @version         3.0.5-chat-fix
 // @updateURL       https://raw.githubusercontent.com/FlamedDogo99/EaglerMobile/main/eaglermobile.user.js
 // @run-at          document-start
 // ==/UserScript==
@@ -54,7 +54,7 @@ Object.defineProperty(EventTarget.prototype, "addEventListener", {
         } else {
 //         	_addEventListener.call(this, type, fn, ...rest);
             _addEventListener.call(this, type, function(...args) {
-				console.log(`%c CALLED ${type}`, 'background: #222; color: #bada55', args);
+// 				console.log(`%c CALLED ${type}`, 'background: #222; color: #bada55', args);
                 return fn.apply(this, args);
             }, ...rest);
         }
@@ -379,7 +379,7 @@ function insertCanvasElements() {
         window.lastKey = inputData
         hiddenInput.value = " "; // We need a character to detect deleting
         if(window.keyboardFix) {
-            if(e.inputType == 'insertText') {
+            if(e.inputType == 'insertText' || e.inputType == 'insertCompositionText') {
                 let isShift = (inputData.toLowerCase() != inputData);
                 if(isShift) {
                     keyEvent("shift", "keydown")

--- a/eaglermobile.user.js
+++ b/eaglermobile.user.js
@@ -47,8 +47,16 @@ Object.defineProperty(EventTarget.prototype, "addEventListener", {
                 }
                 return fn.apply(this, args);
             }, ...rest);
+        } else if (type == 'blur' || type == 'mouseleave') {
+        	_addEventListener.call(this, type, function(...args) {
+                return;
+            }, ...rest);
         } else {
-            _addEventListener.call(this, type, fn, ...rest);
+//         	_addEventListener.call(this, type, fn, ...rest);
+            _addEventListener.call(this, type, function(...args) {
+				console.log(`%c CALLED ${type}`, 'background: #222; color: #bada55', args);
+                return fn.apply(this, args);
+            }, ...rest);
         }
     }
 });
@@ -459,8 +467,28 @@ function insertCanvasElements() {
     document.body.appendChild(pauseButton);
     let chatButton = createTouchButton("chatButton", "inGame");
     chatButton.style.cssText = "top: 0vh; margin: auto; left: 0vh; right: 16vh; width: 8vh; height: 8vh;"
-    chatButton.addEventListener("touchstart", function(e){keyEvent("t", "keydown")}, false);
-    document.body.appendChild(chatButton);
+    chatButton.addEventListener("touchstart", function(e){
+    	window.dispatchEvent(new Event("focus", {
+    		returnValue: true,
+    		srcElement: window,
+    		target: window,
+    		timeStamp: 1
+    	}));
+    	canvas.dispatchEvent(new MouseEvent("mouseenter", {
+    		offsetX: 1,
+    		offsetY: 1,
+    		pageX: 1,
+    		pageY: 1,
+    		screenX: 1,
+    		screenY: 1,
+    		x: 1,
+    		y: 1,
+    		target: canvas,
+    		toElement: canvas,
+    		view: window
+    	}));
+    	keyEvent("t", "keydown");
+    }, false);    document.body.appendChild(chatButton);
     let perspectiveButton = createTouchButton("perspectiveButton", "inGame");
     perspectiveButton.style.cssText = "top: 0vh; margin: auto; left: 0vh; right: 0vh; width: 8vh; height: 8vh;"
     perspectiveButton.addEventListener("touchstart", function(e) {

--- a/eaglermobile.user.js
+++ b/eaglermobile.user.js
@@ -372,7 +372,7 @@ function insertCanvasElements() {
     hiddenInput.id = "hiddenInput"
     hiddenInput.classList.add("inMenu")
     // We are hiding the text input behind button because opacity was causing problems.
-    hiddenInput.style.cssText = "position:absolute;top: 0vh; margin: auto; left: 8vh; right:0vh; width: 8vh; height: 8vh;font-size:20px;z-index:-10;color: transparent;text-shadow: 0 0 0 black;";
+    hiddenInput.style.cssText = "position:absolute;top: 0vh; margin: auto; left: 8vh; right:0vh; width: 8vh; height: 8vh;font-size:20px;z-index:10;";
     hiddenInput.value = " " //Allows delete to be detected before input is changed
     hiddenInput.addEventListener("input", function(e) {
         let inputData = e.data ?? "delete"; // backspace makes null

--- a/eaglermobile.user.js
+++ b/eaglermobile.user.js
@@ -6,7 +6,7 @@
 // @downloadURL     https://raw.githubusercontent.com/FlamedDogo99/EaglerMobile/main/eaglermobile.user.js
 // @license         Apache License 2.0 - http://www.apache.org/licenses/
 // @match           https://eaglercraft.com/mc/*
-// @version         3.0.2
+// @version         3.0.3-chat-fix
 // @updateURL       https://raw.githubusercontent.com/FlamedDogo99/EaglerMobile/main/eaglermobile.user.js
 // @run-at          document-start
 // ==/UserScript==

--- a/eaglermobile.user.js
+++ b/eaglermobile.user.js
@@ -372,7 +372,7 @@ function insertCanvasElements() {
     hiddenInput.id = "hiddenInput"
     hiddenInput.classList.add("inMenu")
     // We are hiding the text input behind button because opacity was causing problems.
-    hiddenInput.style.cssText = "position:absolute;top: 0vh; margin: auto; left: 8vh; right:0vh; width: 8vh; height: 8vh;font-size:20px;z-index:10;";
+    hiddenInput.style.cssText = "position:absolute;top: 0vh; margin: auto; left: 8vh; right:0vh; width: 8vh; height: 8vh;font-size:20px;-index:-10;color: transparent;text-shadow: 0 0 0 black;";
     hiddenInput.value = " " //Allows delete to be detected before input is changed
     hiddenInput.addEventListener("input", function(e) {
         let inputData = e.data ?? "delete"; // backspace makes null


### PR DESCRIPTION
# Attempting to fix android chat focus issue

Possibly resolves #13

### Changes

Updated chatButton to dispatch `mouseenter` and `focus` events before keyEvent is fired

<details>
<summary>See more</summary>

```js
    chatButton.addEventListener("touchstart", function(e){
    	window.dispatchEvent(new Event("focus", {
    		returnValue: true,
    		srcElement: window,
    		target: window,
    		timeStamp: 1
    	}));
    	canvas.dispatchEvent(new MouseEvent("mouseenter", {
    		offsetX: 1,
    		offsetY: 1,
    		pageX: 1,
    		pageY: 1,
    		screenX: 1,
    		screenY: 1,
    		x: 1,
    		y: 1,
    		target: canvas,
    		toElement: canvas,
    		view: window
    	}));
    	keyEvent("t", "keydown");
```

</details>

2. Updated event listener override to ignore `blur` and `mouseleave` events

<details>
<summary>See more</summary>

```js
const _addEventListener = EventTarget.prototype.addEventListener;
Object.defineProperty(EventTarget.prototype, "addEventListener", {
    value: function (type, fn, ...rest) {
        if(type == 'keydown') {
            _addEventListener.call(this, type, function(...args) {
                if(!args[0].isValid && window.keyboardFix) {
                    return;
                }
                return fn.apply(this, args);
            }, ...rest);
        } else if (type == 'blur' || type == 'mouseleave') {
        	_addEventListener.call(this, type, function(...args) {
                return;
            }, ...rest);
        } else {
//         	_addEventListener.call(this, type, fn, ...rest);
            _addEventListener.call(this, type, function(...args) {
				console.log(`%c CALLED ${type}`, 'background: #222; color: #bada55', args);
                return fn.apply(this, args);
            }, ...rest);
        }
    }
});
```

</details>

### Reason for changes

Android currently is not able to select the chat textbox to type. I'm hoping that dispatching the same events as a functional client will allow fix this.

### Tests

Ran on MacOS Safari and Chrome to confirm that events are being dispatched in the the same way that a functioning client would. I'm hoping someone with an Android device can test this

