### PR TITLE
Repo link fix

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -3,7 +3,7 @@
 Whether you want to send us feedback, fix a problem, or something else, you are welcome to contribute! Our code is open source.
 
 
-Be sure to follow our [code of conduct](https://github.com/FlamedDogo99/EaglerMobile/blob/master/.github/CODE_OF_CONDUCT.md).
+Be sure to follow our [code of conduct](https://github.com/FlamedDogo99/EaglerMobile/blob/main/.github/CODE_OF_CONDUCT.md).
 
 ## Reporting bugs and suggesting features
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -28,9 +28,9 @@ Looking for a code editor? We recommend [Visual Studio Code](https://code.visual
 1. **If you have something in mind, it's best if you create or find an issue first (see above). That way, we can discuss it before you start a pull request.**
 2. [Fork this repository](https://docs.github.com/en/get-started/quickstart/fork-a-repo) if you haven't already.
 3. [Clone your fork](https://docs.github.com/en/get-started/quickstart/fork-a-repo#cloning-your-forked-repository) and load it in your browser so you can make and test your changes.
-4. [Create a new branch](https://docs.github.com/en/get-started/quickstart/contributing-to-projects#creating-a-branch-to-work-on), specifying `upstream/master` as the source branch:
+4. [Create a new branch](https://docs.github.com/en/get-started/quickstart/contributing-to-projects#creating-a-branch-to-work-on), specifying `upstream/main` as the source branch:
    ```shell
-   git checkout -b BRANCH-NAME upstream/master
+   git checkout -b BRANCH-NAME upstream/main
    ```
    Branching makes things easier later on if you have multiple pull requests open at once or ever want to contribute again. You can always delete a branch.
 5. Make and test your changes.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 
 [![](https://img.shields.io/github/v/release/FlamedDogo99/EaglerMobile?style=flat-square&logo=github&logoColor=white&label=GitHub&color=181717)](https://github.com/FlamedDogo99/EaglerMobile/releases)
-[![](https://img.shields.io/github/license/FlamedDogo99/EaglerMobile?style=flat-square)](https://github.com/FlamedDogo99/EaglerMobile/blob/master/LICENSE)
+[![](https://img.shields.io/github/license/FlamedDogo99/EaglerMobile?style=flat-square)](https://github.com/FlamedDogo99/EaglerMobile/blob/main/LICENSE)
 
 ## About
 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ If you found a bug or have a suggestion [create an issue](https://github.com/Fla
 
 ### Code
 
-Before contributing code, please read our [contributing guidelines](https://github.com/FlamedDogo99/EaglerMobile/blob/master/.github/CONTRIBUTING.md).
+Before contributing code, please read our [contributing guidelines](https://github.com/FlamedDogo99/EaglerMobile/blob/main/.github/CONTRIBUTING.md).
 
 ### Features and documentation
 #### Fake API's


### PR DESCRIPTION
<!-- Which issue(s) does this pull request fix or resolve? If there aren't any, please submit one first unless this is a hotfix or minor string update. -->

### Changes
Changes repository links and directions to reference `main` branch instead of `master`

### Reason for changes

The links and directions were incorrect

### Tests

Tested on iOS Safari:
```
Mozilla/5.0 (iPhone; CPU iPhone OS 17_5_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.5 Mobile/15E148 Safari/604.1
```