### PR TITLE
Fixes for Android keyboard input, and mobile selection

### DIFF
--- a/eaglermobile.user.js
+++ b/eaglermobile.user.js
@@ -15,7 +15,7 @@
 // THIS IS LAZY AND DANGEROUS AND CAN EXPOSE USERSCRIPT INTERNALS SO PLEASE REMOVE
 // IN THE FUTURE, JUST INJECT A SCRIPT TAG
 try {
-	unsafeWindow.console.log("UNSAFE WINDOW");
+	unsafeWindow.console.log("UNSAFE WINDOW RAGGHHH")
 	alert("DANGER: This userscript is temporarily using unsafeWindow for testing purposes. Unsafe websites could potentially use this to gain access to data and other content that the browser normally wouldn't allow!")
 } catch {
 	Object.defineProperty(window, "unsafeWindow", {
@@ -411,8 +411,7 @@ function insertCanvasElements() {
         unsafeWindow.console.log(`Received input by ${e.inputType}: ${e.data} -> ${inputData}`);
 
         unsafeWindow.lastKey = inputData
-        // TEMP ADD BACK
-//         hiddenInput.value = " "; // We need a character to detect deleting
+        //hiddenInput.value = " ";
         if(unsafeWindow.keyboardFix) {
         	const sliceInputType = e.inputType.slice(0,1); // This is a really dumb way to do this because it's not future-proof
             if(sliceInputType== 'i') {

--- a/eaglermobile.user.js
+++ b/eaglermobile.user.js
@@ -6,7 +6,7 @@
 // @downloadURL     https://raw.githubusercontent.com/FlamedDogo99/EaglerMobile/main/eaglermobile.user.js
 // @license         Apache License 2.0 - http://www.apache.org/licenses/
 // @match           https://eaglercraft.com/mc/*
-// @version         3.0.3-alpha-4
+// @version         3.0.3-alpha-5
 // @updateURL       https://raw.githubusercontent.com/FlamedDogo99/EaglerMobile/main/eaglermobile.user.js
 // @run-at          document-start
 // ==/UserScript==
@@ -14,11 +14,10 @@
 // THIS IS LAZY AND CAN EXPOSE INTERNALS
 // IN THE FUTURE, JUST INJECT A SCRIPT TAG
 
-try {
-window = unsafeWindow ?? window
-} catch {
+var mobileScript = document.createElement("script");
+mobileScript.id = "mobileScript";
+mobileScript.textContent = `
 
-}
 function isMobile() {
     try {
         document.createEvent("TouchEvent");
@@ -62,7 +61,7 @@ function logManager() {
 
 // better charCodeAt function
 String.prototype.toKeyCode = function() {
-    const keyCodeList = {"0": 48, "1": 49, "2": 50, "3": 51, "4": 52, "5": 53, "6": 54, "7": 55, "8": 56, "9": 57, "backspace": 8, "tab": 9, "enter": 13, "shift": 16, "ctrl": 17, "alt": 18, "pause_break": 19, "caps_lock": 20, "escape": 27, " ": 32, "page_up": 33, "page_down": 34, "end": 35, "home": 36, "left_arrow": 37, "up_arrow": 38, "right_arrow": 39, "down_arrow": 40, "insert": 45, "delete": 46, "a": 65, "b": 66, "c": 67, "d": 68, "e": 69, "f": 70, "g": 71, "h": 72, "i": 73, "j": 74, "k": 75, "l": 76, "m": 77, "n": 78, "o": 79, "p": 80, "q": 81, "r": 82, "s": 83, "t": 84, "u": 85, "v": 86, "w": 87, "x": 88, "y": 89, "z": 90, "left_window_key": 91, "right_window_key": 92, "select_key": 93, "numpad_0": 96, "numpad_1": 97, "numpad_2": 98, "numpad_3": 99, "numpad_4": 100, "numpad_5": 101, "numpad_6": 102, "numpad_7": 103, "numpad_8": 104, "numpad_9": 105, "*": 106, "+": 107, "-": 109, ".": 110, "/": 111, "f1": 112, "f2": 113, "f3": 114, "f4": 115, "f5": 116, "f6": 117, "f7": 118, "f8": 119, "f9": 120, "f10": 121, "f11": 122, "f12": 123, "num_lock": 144, "scroll_lock": 145, ";": 186, "=": 187, ",": 188, "-": 189, ".": 190, "/": 191, "`": 192, "[": 219, "\\": 220, "]": 221, "\"": 222};
+    const keyCodeList = {"0": 48, "1": 49, "2": 50, "3": 51, "4": 52, "5": 53, "6": 54, "7": 55, "8": 56, "9": 57, "backspace": 8, "tab": 9, "enter": 13, "shift": 16, "ctrl": 17, "alt": 18, "pause_break": 19, "caps_lock": 20, "escape": 27, " ": 32, "page_up": 33, "page_down": 34, "end": 35, "home": 36, "left_arrow": 37, "up_arrow": 38, "right_arrow": 39, "down_arrow": 40, "insert": 45, "delete": 46, "a": 65, "b": 66, "c": 67, "d": 68, "e": 69, "f": 70, "g": 71, "h": 72, "i": 73, "j": 74, "k": 75, "l": 76, "m": 77, "n": 78, "o": 79, "p": 80, "q": 81, "r": 82, "s": 83, "t": 84, "u": 85, "v": 86, "w": 87, "x": 88, "y": 89, "z": 90, "left_window_key": 91, "right_window_key": 92, "select_key": 93, "numpad_0": 96, "numpad_1": 97, "numpad_2": 98, "numpad_3": 99, "numpad_4": 100, "numpad_5": 101, "numpad_6": 102, "numpad_7": 103, "numpad_8": 104, "numpad_9": 105, "*": 106, "+": 107, "-": 109, ".": 110, "/": 111, "f1": 112, "f2": 113, "f3": 114, "f4": 115, "f5": 116, "f6": 117, "f7": 118, "f8": 119, "f9": 120, "f10": 121, "f11": 122, "f12": 123, "num_lock": 144, "scroll_lock": 145, ";": 186, "=": 187, ",": 188, "-": 189, ".": 190, "/": 191, "\`": 192, "[": 219, "\\": 220, "]": 221, "\"": 222};
     return keyCodeList[this];
 }
 // Ignores keydown events that don't have the isValid parameter set to true
@@ -195,24 +194,6 @@ document.createElement = function(type, ignore) {
     }
     return element;
 }
-
-// Lazy way to hide touch controls through CSS.
-let inGameStyle = document.createElement("style");
-inGameStyle.id = "inGameStyle";
-inGameStyle.textContent = `
-    .inGame {
-        display: none;
-    }`;
-document.documentElement.appendChild(inGameStyle);
-
-let inMenuStyle = document.createElement("style");
-inMenuStyle.id = "inMenuStyle";
-inMenuStyle.textContent = `
-    .inMenu {
-        display: none;
-    }`;
-document.documentElement.appendChild(inMenuStyle);
-
 
 // The canvas is created by the client after it finishes unzipping and loading. When the canvas is created, this applies any necessary event listeners
 function waitForElm(selector) {
@@ -385,8 +366,8 @@ function insertCanvasElements() {
     document.body.appendChild(inventoryButton);
     let exitButton = createTouchButton("exitButton", "inMenu");
     exitButton.style.cssText = "top: 0vh; margin: auto; left: 0vh; right:8vh; width: 8vh; height: 8vh;"
-    exitButton.addEventListener("touchstart", function(e){keyEvent("`", "keydown")}, false);
-    exitButton.addEventListener("touchend", function(e){keyEvent("`", "keyup")}, false);
+    exitButton.addEventListener("touchstart", function(e){keyEvent("\`", "keydown")}, false);
+    exitButton.addEventListener("touchend", function(e){keyEvent("\`", "keyup")}, false);
     document.body.appendChild(exitButton);
     // input for keyboard button
     let hiddenInput = document.createElement('input', true);
@@ -401,7 +382,7 @@ function insertCanvasElements() {
     hiddenInput.addEventListener("input", function(e) {
     	e.preventDefault(true);
         let inputData = e.data == null ? "delete" : e.data.slice(-1);
-        console.log(`Received input by ${e.inputType}: ${e.data} -> ${inputData}`);
+        console.log(\`Received input by ${e.inputType}: ${e.data} -> ${inputData}\`);
 
         window.lastKey = inputData
         hiddenInput.value = " "; // We need a character to detect deleting
@@ -490,8 +471,8 @@ function insertCanvasElements() {
     document.body.appendChild(sprintButton);
     let pauseButton = createTouchButton("pauseButton", "inGame");
     pauseButton.style.cssText = "top: 0vh; margin: auto; left: 0vh; right: 32vh; width: 8vh; height: 8vh;"
-    pauseButton.addEventListener("touchstart", function(e){keyEvent("`", "keydown")}, false);
-    pauseButton.addEventListener("touchend", function(e){keyEvent("`", "keyup")}, false);
+    pauseButton.addEventListener("touchstart", function(e){keyEvent("\`", "keydown")}, false);
+    pauseButton.addEventListener("touchend", function(e){keyEvent("\`", "keyup")}, false);
     document.body.appendChild(pauseButton);
     let chatButton = createTouchButton("chatButton", "inGame");
     chatButton.style.cssText = "top: 0vh; margin: auto; left: 0vh; right: 16vh; width: 8vh; height: 8vh;"
@@ -540,6 +521,24 @@ function insertCanvasElements() {
     document.temp = new logManager();
 	document.temp.init();
 }
+`
+document.documentElement.appendChild(mobileScript)
+// Lazy way to hide touch controls through CSS.
+let inGameStyle = document.createElement("style");
+inGameStyle.id = "inGameStyle";
+inGameStyle.textContent = `
+    .inGame {
+        display: none;
+    }`;
+document.documentElement.appendChild(inGameStyle);
+
+let inMenuStyle = document.createElement("style");
+inMenuStyle.id = "inMenuStyle";
+inMenuStyle.textContent = `
+    .inMenu {
+        display: none;
+    }`;
+document.documentElement.appendChild(inMenuStyle);
 // CSS for touch screen buttons, along with fixing iOS's issues with 100vh ignoring the naviagtion bar, and actually disabling zoom because safari ignores user-scalable=no :(
 let customStyle = document.createElement("style");
 customStyle.textContent = `

--- a/eaglermobile.user.js
+++ b/eaglermobile.user.js
@@ -591,12 +591,8 @@ customStyle.textContent = `
 
     }
     html, body {
-    	height: 100% !important;
-        height: 100dvh !important;
         height: -webkit-fill-available !important;
         height: -moz-available !important;
-        height: fill-available !important;
-		height: stretch !important;
         touch-action: pan-x pan-y;
     }
     .hide {

--- a/eaglermobile.user.js
+++ b/eaglermobile.user.js
@@ -41,9 +41,9 @@ function logManager() {
         self.logger = document.getElementById('log');
         console.log = function (message, options) {
             if (typeof message == 'object') {
-                self.logger.innerHTML = (JSON && JSON.stringify ? JSON.stringify(message) : message) + '<br />' + self.logger.innerHTML;
+                self.logger.innerText = (JSON && JSON.stringify ? JSON.stringify(message) : message) + '<br />' + self.logger.innerHTML;
             } else {
-                self.logger.innerHTML = message + '<br />' + self.logger.innerHTML;
+                self.logger.innerText = message + " " + self.logger.innerText;
             }
         }
     }
@@ -524,7 +524,7 @@ function insertCanvasElements() {
     }, false);
     document.body.appendChild(coordinatesButton);
     //TEMP REMOVE
-    var temp = document.createElement("div");
+    var temp = document.createElement("p");
     temp.id = "log";
     temp.classList.add("log");
     temp.style.cssText= "position: absolute; top: 8vh; margin: auto; left: 0vh; right: 0vh; height: auto; z-index:10; min-height:8vh; background:white";

--- a/eaglermobile.user.js
+++ b/eaglermobile.user.js
@@ -6,7 +6,7 @@
 // @downloadURL     https://raw.githubusercontent.com/FlamedDogo99/EaglerMobile/main/eaglermobile.user.js
 // @license         Apache License 2.0 - http://www.apache.org/licenses/
 // @match           https://eaglercraft.com/mc/*
-// @version         3.0.2
+// @version         3.0.3-alpha-1
 // @updateURL       https://raw.githubusercontent.com/FlamedDogo99/EaglerMobile/main/eaglermobile.user.js
 // @run-at          document-start
 // ==/UserScript==
@@ -54,8 +54,8 @@ Object.defineProperty(EventTarget.prototype, "addEventListener", {
 });
 // Allows typing in #hiddenInput
 const _preventDefault = Event.prototype.preventDefault;
-Event.prototype.preventDefault = function() {
-  if(document.activeElement.id != "hiddenInput") {
+Event.prototype.preventDefault = function(shouldBypass) {
+  if(document.activeElement.id != "hiddenInput" || shouldBypass) {
       this._preventDefault =  _preventDefault;
       this._preventDefault();
   }
@@ -367,11 +367,13 @@ function insertCanvasElements() {
     hiddenInput.style.cssText = "position:absolute;top: 0vh; margin: auto; left: 8vh; right:0vh; width: 8vh; height: 8vh;font-size:20px;z-index:-10;color: transparent;text-shadow: 0 0 0 black;";
     hiddenInput.value = " " //Allows delete to be detected before input is changed
     hiddenInput.addEventListener("input", function(e) {
-        let inputData = e.data ?? "delete"; // backspace makes null
+    	e.preventDefault(true);
+        let inputData = e.data == null ? "delete" : e.data.slice(-1); // backspace makes null
         window.lastKey = inputData
         hiddenInput.value = " "; // We need a character to detect deleting
         if(window.keyboardFix) {
-            if(e.inputType == 'insertText') {
+        	const sliceInputType = e.inputType.slice(0,1); // This is a really dumb way to do this because it's not future-proof
+            if(sliceInputType== 'i') {
                 let isShift = (inputData.toLowerCase() != inputData);
                 if(isShift) {
                     keyEvent("shift", "keydown")
@@ -382,9 +384,9 @@ function insertCanvasElements() {
                     keyEvent(inputData, "keydown");
                     keyEvent(inputData, "keyup");
                 }
-            } else if (e.inputType == 'deleteContentForward' || e.inputType == 'deleteContentBackward') {
-                keyEvent("backspace", "keydown")
-                keyEvent("backspace", "keyup")
+            } else if (sliceInputType == 'd') {
+                keyEvent("backspace", "keydown");
+                keyEvent("backspace", "keyup");
             }
         }
     }, false);
@@ -393,8 +395,8 @@ function insertCanvasElements() {
         	console.warn("Switching from keydown to input events due to invalid KeyboardEvent. Some functionality will be lost.")
             window.keyboardFix = true;
             if(window.lastKey) {
-            	keyEvent(window.lastKey, "keydown")
-            	keyEvent(window.lastKey, "keyup")
+            	keyEvent(window.lastKey, "keydown");
+            	keyEvent(window.lastKey, "keyup");
             }
         }
     }, false);

--- a/eaglermobile.user.js
+++ b/eaglermobile.user.js
@@ -6,7 +6,7 @@
 // @downloadURL     https://raw.githubusercontent.com/FlamedDogo99/EaglerMobile/main/eaglermobile.user.js
 // @license         Apache License 2.0 - http://www.apache.org/licenses/
 // @match           https://eaglercraft.com/mc/*
-// @version         3.0.3-alpha-1
+// @version         3.0.3-alpha-2
 // @updateURL       https://raw.githubusercontent.com/FlamedDogo99/EaglerMobile/main/eaglermobile.user.js
 // @run-at          document-start
 // ==/UserScript==
@@ -524,7 +524,7 @@ function insertCanvasElements() {
     var temp = document.createElement("div");
     temp.id = "log";
     temp.classList.add("log");
-    temp.style.cssText= "position:absolute; top: 8vh; margin: auto; left: 0vh; right:0vh";
+    temp.style.cssText= "position:absolute; top: 8vh; margin: auto; left: 0vh; right:0vh; height: 30vh;";
     temp.innerHtml = "Loading..."
     document.body.appendChild(temp);
     document.temp = new logManager();

--- a/eaglermobile.user.js
+++ b/eaglermobile.user.js
@@ -592,7 +592,6 @@ customStyle.textContent = `
     }
     html, body {
         height: -webkit-fill-available !important;
-        height: -moz-available !important;
         touch-action: pan-x pan-y;
     }
     .hide {

--- a/eaglermobile.user.js
+++ b/eaglermobile.user.js
@@ -12,17 +12,10 @@
 // @grant           unsafeWindow
 // ==/UserScript==
 
-// THIS IS LAZY AND CAN EXPOSE INTERNALS
+// THIS IS LAZY AND DANGEROUS AND CAN EXPOSE USERSCRIPT INTERNALS SO PLEASE REMOVE
 // IN THE FUTURE, JUST INJECT A SCRIPT TAG
-//try {
-//var window = unsafeWindow ?? window
-//} catch {
-//
-//}
 try {
-	if(unsafeWindow) {
-		console.log("UNSAFE WINDOW RAGGHHH")
-	}
+	unsafeWindow.console.log("UNSAFE WINDOW RAGGHHH")
 } catch {
 	Object.defineProperty(window, "unsafeWindow", {
 		value: window
@@ -437,7 +430,7 @@ function insertCanvasElements() {
         }
     }, false);
     hiddenInput.addEventListener("keydown", function(e) {
-        if(!(e.key && e.keyCode && e.which) && !unsafeWindow.keyboardFix) {
+        if((e.keyCode = 229 || e.which = 229) && !unsafeWindow.keyboardFix) {
         	unsafeWindow.console.warn("Switching from keydown to input events due to invalid KeyboardEvent. Some functionality will be lost.")
             unsafeWindow.keyboardFix = true;
             if(unsafeWindow.lastKey) {

--- a/eaglermobile.user.js
+++ b/eaglermobile.user.js
@@ -386,12 +386,15 @@ function insertCanvasElements() {
     hiddenInput.id = "hiddenInput"
     hiddenInput.classList.add("inMenu")
     // We are hiding the text input behind button because opacity was causing problems.
-    hiddenInput.style.cssText = "position:absolute;top: 0vh; margin: auto; left: 8vh; right:0vh; width: 8vh; height: 8vh;font-size:20px;z-index:-10;color: transparent;text-shadow: 0 0 0 black;";
+    //TEMP REVERT
+    //hiddenInput.style.cssText = "position:absolute;top: 0vh; margin: auto; left: 8vh; right:0vh; width: 8vh; height: 8vh;font-size:20px;z-index:-10;color: transparent;text-shadow: 0 0 0 black;";
+
+    hiddenInput.style.cssText = "position:absolute;top: 0vh; margin: auto; left: 8vh; right:0vh; width: 8vh; height: 8vh;font-size:20px;z-index:10";
     hiddenInput.value = " " //Allows delete to be detected before input is changed
     hiddenInput.addEventListener("input", function(e) {
     	e.preventDefault(true);
         let inputData = e.data == null ? "delete" : e.data.slice(-1);
-        console.log("Received input!", inputData, e.inputType)
+        console.log(`Received input by ${e.inputType}: ${e.data} -> ${inputData}`);
 
         window.lastKey = inputData
         hiddenInput.value = " "; // We need a character to detect deleting

--- a/eaglermobile.user.js
+++ b/eaglermobile.user.js
@@ -31,6 +31,28 @@ window.keyboardFix = false; // temporarily set to true until I can figure out wh
 var previousTouchX = null;
 var previousTouchY = null;
 var startTouchX = null;
+//TEMP REMOVE
+function logManager() {
+    var self = this;
+
+    self.init = function () {
+        console.log('logmanager initialized');
+        var old = console.log;
+        self.logger = document.getElementById('log');
+        console.log = function (message, options) {
+            if (typeof message == 'object') {
+                self.logger.innerHTML = (JSON && JSON.stringify ? JSON.stringify(message) : message) + '<br />' + self.logger.innerHTML;
+            } else {
+                self.logger.innerHTML = message + '<br />' + self.logger.innerHTML;
+            }
+        }
+    }
+    self.toggleLogVisibility = function () {
+        return $(self.logger).toggle();
+    };
+}
+
+
 // better charCodeAt function
 String.prototype.toKeyCode = function() {
     const keyCodeList = {"0": 48, "1": 49, "2": 50, "3": 51, "4": 52, "5": 53, "6": 54, "7": 55, "8": 56, "9": 57, "backspace": 8, "tab": 9, "enter": 13, "shift": 16, "ctrl": 17, "alt": 18, "pause_break": 19, "caps_lock": 20, "escape": 27, " ": 32, "page_up": 33, "page_down": 34, "end": 35, "home": 36, "left_arrow": 37, "up_arrow": 38, "right_arrow": 39, "down_arrow": 40, "insert": 45, "delete": 46, "a": 65, "b": 66, "c": 67, "d": 68, "e": 69, "f": 70, "g": 71, "h": 72, "i": 73, "j": 74, "k": 75, "l": 76, "m": 77, "n": 78, "o": 79, "p": 80, "q": 81, "r": 82, "s": 83, "t": 84, "u": 85, "v": 86, "w": 87, "x": 88, "y": 89, "z": 90, "left_window_key": 91, "right_window_key": 92, "select_key": 93, "numpad_0": 96, "numpad_1": 97, "numpad_2": 98, "numpad_3": 99, "numpad_4": 100, "numpad_5": 101, "numpad_6": 102, "numpad_7": 103, "numpad_8": 104, "numpad_9": 105, "*": 106, "+": 107, "-": 109, ".": 110, "/": 111, "f1": 112, "f2": 113, "f3": 114, "f4": 115, "f5": 116, "f6": 117, "f7": 118, "f8": 119, "f9": 120, "f10": 121, "f11": 122, "f12": 123, "num_lock": 144, "scroll_lock": 145, ";": 186, "=": 187, ",": 188, "-": 189, ".": 190, "/": 191, "`": 192, "[": 219, "\\": 220, "]": 221, "\"": 222};
@@ -488,7 +510,7 @@ function insertCanvasElements() {
     }, false);
     document.body.appendChild(screenshotButton);
     let coordinatesButton = createTouchButton("coordinatesButton", "inGame");
-    coordinatesButton.style.cssText = "top: 0vh; margin: auto; left: 32vh; right: 0vh; width: 8vh; height: 8vh;"
+    coordinatesButton.style.cssText = ""
     coordinatesButton.addEventListener("touchstart", function(e) {
         keyEvent("f", "keydown");
         keyEvent("3", "keydown");
@@ -498,6 +520,15 @@ function insertCanvasElements() {
         keyEvent("3", "keyup");
     }, false);
     document.body.appendChild(coordinatesButton);
+    //TEMP REMOVE
+    var temp = document.createElement("div");
+    temp.id = "log";
+    temp.classList.add("log");
+    temp.style.cssText= "position:absolute; top: 8vh; margin: auto; left: 0vh; right:0vh";
+    temp.innerHtml = "Loading..."
+    document.body.appendChild(temp);
+    document.temp = new logManager();
+	document.temp.init();
 }
 // CSS for touch screen buttons, along with fixing iOS's issues with 100vh ignoring the naviagtion bar, and actually disabling zoom because safari ignores user-scalable=no :(
 let customStyle = document.createElement("style");

--- a/eaglermobile.user.js
+++ b/eaglermobile.user.js
@@ -368,7 +368,9 @@ function insertCanvasElements() {
     hiddenInput.value = " " //Allows delete to be detected before input is changed
     hiddenInput.addEventListener("input", function(e) {
     	e.preventDefault(true);
-        let inputData = e.data == null ? "delete" : e.data.slice(-1); // backspace makes null
+        let inputData = e.data == null ? "delete" : e.data.slice(-1);
+        console.log("Received input!", inputData, e.inputType)
+
         window.lastKey = inputData
         hiddenInput.value = " "; // We need a character to detect deleting
         if(window.keyboardFix) {

--- a/eaglermobile.user.js
+++ b/eaglermobile.user.js
@@ -6,7 +6,7 @@
 // @downloadURL     https://raw.githubusercontent.com/FlamedDogo99/EaglerMobile/main/eaglermobile.user.js
 // @license         Apache License 2.0 - http://www.apache.org/licenses/
 // @match           https://eaglercraft.com/mc/*
-// @version         3.0.3-alpha-2
+// @version         3.0.3-alpha-3
 // @updateURL       https://raw.githubusercontent.com/FlamedDogo99/EaglerMobile/main/eaglermobile.user.js
 // @run-at          document-start
 // ==/UserScript==
@@ -524,7 +524,7 @@ function insertCanvasElements() {
     var temp = document.createElement("div");
     temp.id = "log";
     temp.classList.add("log");
-    temp.style.cssText= "position:absolute; top: 8vh; margin: auto; left: 0vh; right:0vh; height: 30vh;";
+    temp.style.cssText= "position: absolute; top: 8vh; margin: auto; left: 0vh; right: 0vh; height: auto; z-index:10; min-height:8vh; background:white";
     temp.innerHtml = "Loading..."
     document.body.appendChild(temp);
     document.temp = new logManager();

--- a/eaglermobile.user.js
+++ b/eaglermobile.user.js
@@ -227,6 +227,7 @@ function createTouchButton(buttonClass, buttonDisplay, elementName) {
     touchButton.classList.add(buttonDisplay);
     touchButton.classList.add("mobileControl");
     touchButton.addEventListener("touchmove", function(e){e.preventDefault()}, false);
+    touchButton.addEventListener(“contextmenu”, function(e){e.preventDefault()});
     return touchButton;
 }
 
@@ -550,6 +551,7 @@ customStyle.textContent = `
         outline:none;
         box-shadow: none;
         border: none;
+        pointer-events: none !important;
     }
     .mobileControl:active, .mobileControl.active {
         position: absolute; 
@@ -570,11 +572,19 @@ customStyle.textContent = `
         outline:none;
         box-shadow: none;
         border: none;
-
+		pointer-events: none !important;
     }
-    html, body {
+    html, body, canvas {
         height: -webkit-fill-available !important;
         touch-action: pan-x pan-y;
+        -webkit-touch-callout: none;
+        -webkit-user-select: none;
+        -khtml-user-select: none;
+        -moz-user-select: none;
+        -ms-user-select: none;
+        user-select: none;
+        outline: none;
+        -webkit-tap-highlight-color: rgba(255, 255, 255, 0);
     }
     .hide {
         display: none;

--- a/eaglermobile.user.js
+++ b/eaglermobile.user.js
@@ -15,7 +15,7 @@
 // THIS IS LAZY AND DANGEROUS AND CAN EXPOSE USERSCRIPT INTERNALS SO PLEASE REMOVE
 // IN THE FUTURE, JUST INJECT A SCRIPT TAG
 try {
-	unsafeWindow.console.log("UNSAFE WINDOW RAGGHHH")
+	unsafeWindow.console.log("UNSAFE WINDOW");
 	alert("DANGER: This userscript is temporarily using unsafeWindow for testing purposes. Unsafe websites could potentially use this to gain access to data and other content that the browser normally wouldn't allow!")
 } catch {
 	Object.defineProperty(window, "unsafeWindow", {
@@ -411,7 +411,8 @@ function insertCanvasElements() {
         unsafeWindow.console.log(`Received input by ${e.inputType}: ${e.data} -> ${inputData}`);
 
         unsafeWindow.lastKey = inputData
-        hiddenInput.value = " "; // We need a character to detect deleting
+        // TEMP ADD BACK
+//         hiddenInput.value = " "; // We need a character to detect deleting
         if(unsafeWindow.keyboardFix) {
         	const sliceInputType = e.inputType.slice(0,1); // This is a really dumb way to do this because it's not future-proof
             if(sliceInputType== 'i') {
@@ -590,7 +591,12 @@ customStyle.textContent = `
 
     }
     html, body {
+    	height: 100% !important;
+        height: 100dvh !important;
         height: -webkit-fill-available !important;
+        height: -moz-available !important;
+        height: fill-available !important;
+		height: stretch !important;
         touch-action: pan-x pan-y;
     }
     .hide {

--- a/eaglermobile.user.js
+++ b/eaglermobile.user.js
@@ -15,14 +15,14 @@
 // This is generally a bad practice, but we need to run scripts in the main context before the DOM loads. Because we are only matching eaglercraft.com, the use of unsafeWindow should be safe to use.
 // If someone knows a better way of doing this, please create an issue
 try {
-	unsafeWindow.console.warn("DANGER: This userscript is  using unsafeWindow. Unsafe websites could potentially use this to gain access to data and other content that the browser normally wouldn't allow!")
+    unsafeWindow.console.warn("DANGER: This userscript is  using unsafeWindow. Unsafe websites could potentially use this to gain access to data and other content that the browser normally wouldn't allow!")
     Object.defineProperty(window, "clientWindow", {
-		value: unsafeWindow
-	});
+        value: unsafeWindow
+    });
 } catch {
-	Object.defineProperty(window, "clientWindow", {
-		value: window
-	});
+    Object.defineProperty(window, "clientWindow", {
+        value: window
+    });
 }
 
 function isMobile() {
@@ -112,12 +112,12 @@ function setButtonVisibility(pointerLocked) {
 clientWindow.fakelock = null;
 
 Object.defineProperty(Element.prototype, "requestPointerLock", {
-	value: function() {
-		clientWindow.fakelock = this
-		document.dispatchEvent(new Event('pointerlockchange'));
-		setButtonVisibility(true);
-		return true
-	}
+    value: function() {
+        clientWindow.fakelock = this
+        document.dispatchEvent(new Event('pointerlockchange'));
+        setButtonVisibility(true);
+        return true
+    }
 });
 
 
@@ -129,23 +129,23 @@ Object.defineProperty(Document.prototype, "pointerLockElement", {
 });
 // When exitPointerLock is called, this dispatches an event, clears the
 Object.defineProperty(Document.prototype, "exitPointerLock", {
-	value: function() {
-		clientWindow.fakelock = null
-		document.dispatchEvent(new Event('pointerlockchange'));
-		setButtonVisibility(false);
-		return true
-	}
+    value: function() {
+        clientWindow.fakelock = null
+        document.dispatchEvent(new Event('pointerlockchange'));
+        setButtonVisibility(false);
+        return true
+    }
 });
 
 // FULLSCREEN
 clientWindow.fakefull = null;
 // Stops the client from crashing when fullscreen is requested
 Object.defineProperty(Element.prototype, "requestFullscreen", {
-	value: function() {
-		clientWindow.fakefull = this
-		document.dispatchEvent(new Event('fullscreenchange'));
-		return true
-	}
+    value: function() {
+        clientWindow.fakefull = this
+        document.dispatchEvent(new Event('fullscreenchange'));
+        return true
+    }
 });
 Object.defineProperty(document, "fullscreenElement", {
     get: function() {
@@ -153,11 +153,11 @@ Object.defineProperty(document, "fullscreenElement", {
     }
 });
 Object.defineProperty(Document.prototype, "exitFullscreen", {
-	value: function() {
-		clientWindow.fakefull = null
-		document.dispatchEvent(new Event('fullscreenchange'));
-		return true
-	}
+    value: function() {
+        clientWindow.fakefull = null
+        document.dispatchEvent(new Event('fullscreenchange'));
+        return true
+    }
 });
 
 // FILE UPLOADING
@@ -168,16 +168,16 @@ document.createElement = function(type, ignore) {
     this._createElement = _createElement;
     var element = this._createElement(type);
     if(type == "input" && !ignore) {
-    	document.querySelectorAll('#fileUpload').forEach(e => e.parentNode.removeChild(e));
-    	element.id = "fileUpload";
-    	element.addEventListener('change', function(e) {
-    		element.hidden = true;
-    		element.style.display = "none";
-    	}, {passive: false, once: true});
-    	clientWindow.addEventListener('focus', function(e) {
+        document.querySelectorAll('#fileUpload').forEach(e => e.parentNode.removeChild(e));
+        element.id = "fileUpload";
+        element.addEventListener('change', function(e) {
+            element.hidden = true;
+            element.style.display = "none";
+        }, {passive: false, once: true});
+        clientWindow.addEventListener('focus', function(e) {
             setTimeout(() => {
                 element.hidden = true;
-    			element.style.display = "none";
+                element.style.display = "none";
             }, 300)
         }, { once: true })
         document.body.appendChild(element);
@@ -387,34 +387,34 @@ function insertCanvasElements() {
     hiddenInput.value = " " //Allows delete to be detected before input is changed
     hiddenInput.addEventListener("input", function(e) {
         e.stopImmediatePropagation();
-    	e.preventDefault(true);
+        e.preventDefault(true);
         let inputData = e.data == null ? "delete" : e.data.slice(-1);
         if(!clientWindow.lastKey) { // If we get an event before any keys have been pressed, we know that setting the hiddenInput creates duplicate input events, so we can apply the fix
-        	clientWindow.console.warn("Enabling blocking duplicate key events. Some functionality may be lost.")
-        	clientWindow.inputFix = true;
+            clientWindow.console.warn("Enabling blocking duplicate key events. Some functionality may be lost.")
+            clientWindow.inputFix = true;
         }
         clientWindow.console.log(`Received input by ${e.inputType}: ${e.data} -> ${inputData}`);
 
         hiddenInput.value = " ";
         if(clientWindow.keyboardFix) {
-        	const sliceInputType = e.inputType.slice(0,1); // This is a really dumb way to do this because it's not future-proof, but its the easiest way to deal with Android
+            const sliceInputType = e.inputType.slice(0,1); // This is a really dumb way to do this because it's not future-proof, but its the easiest way to deal with Android
             if(sliceInputType== 'i') {
-				const isDuplicate = (clientWindow.lastKey == inputData) && clientWindow.blockNextInput && clientWindow.inputFix;
-				if(isDuplicate) {
-            		clientWindow.blockNextInput = false;
-            	} else {
-					let isShift = (inputData.toLowerCase() != inputData);
-					if(isShift) {
-						keyEvent("shift", "keydown")
-						keyEvent(inputData, "keydown");
-						keyEvent(inputData, "keyup");
-						keyEvent("shift", "keyup")
-					} else {
-						keyEvent(inputData, "keydown");
-						keyEvent(inputData, "keyup");
-					}
-					clientWindow.blockNextInput = true;
-				}
+                const isDuplicate = (clientWindow.lastKey == inputData) && clientWindow.blockNextInput && clientWindow.inputFix;
+                if(isDuplicate) {
+                    clientWindow.blockNextInput = false;
+                } else {
+                    let isShift = (inputData.toLowerCase() != inputData);
+                    if(isShift) {
+                        keyEvent("shift", "keydown")
+                        keyEvent(inputData, "keydown");
+                        keyEvent(inputData, "keyup");
+                        keyEvent("shift", "keyup")
+                    } else {
+                        keyEvent(inputData, "keydown");
+                        keyEvent(inputData, "keyup");
+                    }
+                    clientWindow.blockNextInput = true;
+                }
             } else if (sliceInputType == 'd') {
                 keyEvent("backspace", "keydown");
                 keyEvent("backspace", "keyup");
@@ -426,11 +426,11 @@ function insertCanvasElements() {
     }, false);
     hiddenInput.addEventListener("keydown", function(e) {
         if((e.keyCode == 229 || e.which == 229) && !clientWindow.keyboardFix) {
-        	clientWindow.console.warn("Switching from keydown to input events due to invalid KeyboardEvent. Some functionality will be lost.")
+            clientWindow.console.warn("Switching from keydown to input events due to invalid KeyboardEvent. Some functionality will be lost.")
             clientWindow.keyboardFix = true;
             if(clientWindow.lastKey) {
-            	keyEvent(clientWindow.lastKey, "keydown");
-            	keyEvent(clientWindow.lastKey, "keyup");
+                keyEvent(clientWindow.lastKey, "keydown");
+                keyEvent(clientWindow.lastKey, "keyup");
             }
         }
     }, false);
@@ -572,7 +572,7 @@ customStyle.textContent = `
         outline:none;
         box-shadow: none;
         border: none;
-		pointer-events: none !important;
+        pointer-events: none !important;
     }
     html, body, canvas {
         height: -webkit-fill-available !important;
@@ -590,14 +590,14 @@ customStyle.textContent = `
         display: none;
     }
     #fileUpload {
-    	position: absolute;
-    	left: 0;
-    	right: 100vw;
-    	top: 0; 
-    	bottom: 100vh;
-    	width: 100vw;
-    	height: 100vh;
-    	background-color:rgba(255,255,255,0.5);
+        position: absolute;
+        left: 0;
+        right: 100vw;
+        top: 0; 
+        bottom: 100vh;
+        width: 100vw;
+        height: 100vh;
+        background-color:rgba(255,255,255,0.5);
     }
     .strafeRightButton {
     background-image: url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABYAAAAWCAYAAADEtGw7AAAABGdBTUEAALGPC/xhBQAAACBjSFJNAAB6JgAAgIQAAPoAAACA6AAAdTAAAOpgAAA6mAAAF3CculE8AAAAUGVYSWZNTQAqAAAACAACARIAAwAAAAEAAQAAh2kABAAAAAEAAAAmAAAAAAADoAEAAwAAAAEAAQAAoAIABAAAAAEAAAAWoAMABAAAAAEAAAAWAAAAAA78HUQAAAIwaVRYdFhNTDpjb20uYWRvYmUueG1wAAAAAAA8eDp4bXBtZXRhIHhtbG5zOng9ImFkb2JlOm5zOm1ldGEvIiB4OnhtcHRrPSJYTVAgQ29yZSA2LjAuMCI+CiAgIDxyZGY6UkRGIHhtbG5zOnJkZj0iaHR0cDovL3d3dy53My5vcmcvMTk5OS8wMi8yMi1yZGYtc3ludGF4LW5zIyI+CiAgICAgIDxyZGY6RGVzY3JpcHRpb24gcmRmOmFib3V0PSIiCiAgICAgICAgICAgIHhtbG5zOmV4aWY9Imh0dHA6Ly9ucy5hZG9iZS5jb20vZXhpZi8xLjAvIgogICAgICAgICAgICB4bWxuczp0aWZmPSJodHRwOi8vbnMuYWRvYmUuY29tL3RpZmYvMS4wLyI+CiAgICAgICAgIDxleGlmOlBpeGVsWURpbWVuc2lvbj4yMjwvZXhpZjpQaXhlbFlEaW1lbnNpb24+CiAgICAgICAgIDxleGlmOlBpeGVsWERpbWVuc2lvbj4yMjwvZXhpZjpQaXhlbFhEaW1lbnNpb24+CiAgICAgICAgIDxleGlmOkNvbG9yU3BhY2U+MTwvZXhpZjpDb2xvclNwYWNlPgogICAgICAgICA8dGlmZjpPcmllbnRhdGlvbj4xPC90aWZmOk9yaWVudGF0aW9uPgogICAgICA8L3JkZjpEZXNjcmlwdGlvbj4KICAgPC9yZGY6UkRGPgo8L3g6eG1wbWV0YT4KhDb0tQAAANRJREFUOBHVlMENwyAMRWnVHcqIjMEYzJAemlUidQh6aFZIApIt20FgUC/JxTb8/2wRgTFX+25i4E3UvSXyMDkIGeqc64VlfQgBfJnJwAC11oJIFWOMFJ6Zd+nshSZ/yXMCy0aj9aPH6L1HOc1xkSQqcAtCeJhWwSNAIA+dsaZhFawBwIQyVsFJLOGylkCom+ASHMy1WP151KidFDynieF6gkATSx42cYzf43o+TUnYajBNLyZh4LSzLB8mGC3YUczze5Rj1vXHvPTZTBt/e+hZl0sUO9qPMTJ6UlWFAAAAAElFTkSuQmCC");

--- a/eaglermobile.user.js
+++ b/eaglermobile.user.js
@@ -6,17 +6,20 @@
 // @downloadURL     https://raw.githubusercontent.com/FlamedDogo99/EaglerMobile/main/eaglermobile.user.js
 // @license         Apache License 2.0 - http://www.apache.org/licenses/
 // @match           https://eaglercraft.com/mc/*
-// @version         3.0.3-alpha-5
+// @version         3.0.3-alpha-4
 // @updateURL       https://raw.githubusercontent.com/FlamedDogo99/EaglerMobile/main/eaglermobile.user.js
 // @run-at          document-start
+// @grant           unsafeWindow
 // ==/UserScript==
 
 // THIS IS LAZY AND CAN EXPOSE INTERNALS
 // IN THE FUTURE, JUST INJECT A SCRIPT TAG
 
-var mobileScript = document.createElement("script");
-mobileScript.id = "mobileScript";
-mobileScript.textContent = `
+try {
+window = unsafeWindow ?? window
+} catch {
+
+}
 
 function isMobile() {
     try {
@@ -61,7 +64,8 @@ function logManager() {
 
 // better charCodeAt function
 String.prototype.toKeyCode = function() {
-    const keyCodeList = {"0": 48, "1": 49, "2": 50, "3": 51, "4": 52, "5": 53, "6": 54, "7": 55, "8": 56, "9": 57, "backspace": 8, "tab": 9, "enter": 13, "shift": 16, "ctrl": 17, "alt": 18, "pause_break": 19, "caps_lock": 20, "escape": 27, " ": 32, "page_up": 33, "page_down": 34, "end": 35, "home": 36, "left_arrow": 37, "up_arrow": 38, "right_arrow": 39, "down_arrow": 40, "insert": 45, "delete": 46, "a": 65, "b": 66, "c": 67, "d": 68, "e": 69, "f": 70, "g": 71, "h": 72, "i": 73, "j": 74, "k": 75, "l": 76, "m": 77, "n": 78, "o": 79, "p": 80, "q": 81, "r": 82, "s": 83, "t": 84, "u": 85, "v": 86, "w": 87, "x": 88, "y": 89, "z": 90, "left_window_key": 91, "right_window_key": 92, "select_key": 93, "numpad_0": 96, "numpad_1": 97, "numpad_2": 98, "numpad_3": 99, "numpad_4": 100, "numpad_5": 101, "numpad_6": 102, "numpad_7": 103, "numpad_8": 104, "numpad_9": 105, "*": 106, "+": 107, "-": 109, ".": 110, "/": 111, "f1": 112, "f2": 113, "f3": 114, "f4": 115, "f5": 116, "f6": 117, "f7": 118, "f8": 119, "f9": 120, "f10": 121, "f11": 122, "f12": 123, "num_lock": 144, "scroll_lock": 145, ";": 186, "=": 187, ",": 188, "-": 189, ".": 190, "/": 191, "\`": 192, "[": 219, "\\\": 220, "]": 221, "\\"": 222};
+        const keyCodeList = {"0": 48, "1": 49, "2": 50, "3": 51, "4": 52, "5": 53, "6": 54, "7": 55, "8": 56, "9": 57, "backspace": 8, "tab": 9, "enter": 13, "shift": 16, "ctrl": 17, "alt": 18, "pause_break": 19, "caps_lock": 20, "escape": 27, " ": 32, "page_up": 33, "page_down": 34, "end": 35, "home": 36, "left_arrow": 37, "up_arrow": 38, "right_arrow": 39, "down_arrow": 40, "insert": 45, "delete": 46, "a": 65, "b": 66, "c": 67, "d": 68, "e": 69, "f": 70, "g": 71, "h": 72, "i": 73, "j": 74, "k": 75, "l": 76, "m": 77, "n": 78, "o": 79, "p": 80, "q": 81, "r": 82, "s": 83, "t": 84, "u": 85, "v": 86, "w": 87, "x": 88, "y": 89, "z": 90, "left_window_key": 91, "right_window_key": 92, "select_key": 93, "numpad_0": 96, "numpad_1": 97, "numpad_2": 98, "numpad_3": 99, "numpad_4": 100, "numpad_5": 101, "numpad_6": 102, "numpad_7": 103, "numpad_8": 104, "numpad_9": 105, "*": 106, "+": 107, "-": 109, ".": 110, "/": 111, "f1": 112, "f2": 113, "f3": 114, "f4": 115, "f5": 116, "f6": 117, "f7": 118, "f8": 119, "f9": 120, "f10": 121, "f11": 122, "f12": 123, "num_lock": 144, "scroll_lock": 145, ";": 186, "=": 187, ",": 188, "-": 189, ".": 190, "/": 191, "\u0060": 192, "[": 219, "\u005C": 220, "]": 221, "\u0022": 222};
+
     return keyCodeList[this];
 }
 // Ignores keydown events that don't have the isValid parameter set to true
@@ -194,6 +198,24 @@ document.createElement = function(type, ignore) {
     }
     return element;
 }
+
+// Lazy way to hide touch controls through CSS.
+let inGameStyle = document.createElement("style");
+inGameStyle.id = "inGameStyle";
+inGameStyle.textContent = `
+    .inGame {
+        display: none;
+    }`;
+document.documentElement.appendChild(inGameStyle);
+
+let inMenuStyle = document.createElement("style");
+inMenuStyle.id = "inMenuStyle";
+inMenuStyle.textContent = `
+    .inMenu {
+        display: none;
+    }`;
+document.documentElement.appendChild(inMenuStyle);
+
 
 // The canvas is created by the client after it finishes unzipping and loading. When the canvas is created, this applies any necessary event listeners
 function waitForElm(selector) {
@@ -366,8 +388,8 @@ function insertCanvasElements() {
     document.body.appendChild(inventoryButton);
     let exitButton = createTouchButton("exitButton", "inMenu");
     exitButton.style.cssText = "top: 0vh; margin: auto; left: 0vh; right:8vh; width: 8vh; height: 8vh;"
-    exitButton.addEventListener("touchstart", function(e){keyEvent("\`", "keydown")}, false);
-    exitButton.addEventListener("touchend", function(e){keyEvent("\`", "keyup")}, false);
+    exitButton.addEventListener("touchstart", function(e){keyEvent("`", "keydown")}, false);
+    exitButton.addEventListener("touchend", function(e){keyEvent("`", "keyup")}, false);
     document.body.appendChild(exitButton);
     // input for keyboard button
     let hiddenInput = document.createElement('input', true);
@@ -382,7 +404,7 @@ function insertCanvasElements() {
     hiddenInput.addEventListener("input", function(e) {
     	e.preventDefault(true);
         let inputData = e.data == null ? "delete" : e.data.slice(-1);
-        console.log("Received input by " + e.inputType + ": " + e.data + " -> " + inputData);
+        console.log(`Received input by ${e.inputType}: ${e.data} -> ${inputData}`);
 
         window.lastKey = inputData
         hiddenInput.value = " "; // We need a character to detect deleting
@@ -471,8 +493,8 @@ function insertCanvasElements() {
     document.body.appendChild(sprintButton);
     let pauseButton = createTouchButton("pauseButton", "inGame");
     pauseButton.style.cssText = "top: 0vh; margin: auto; left: 0vh; right: 32vh; width: 8vh; height: 8vh;"
-    pauseButton.addEventListener("touchstart", function(e){keyEvent("\`", "keydown")}, false);
-    pauseButton.addEventListener("touchend", function(e){keyEvent("\`", "keyup")}, false);
+    pauseButton.addEventListener("touchstart", function(e){keyEvent("`", "keydown")}, false);
+    pauseButton.addEventListener("touchend", function(e){keyEvent("`", "keyup")}, false);
     document.body.appendChild(pauseButton);
     let chatButton = createTouchButton("chatButton", "inGame");
     chatButton.style.cssText = "top: 0vh; margin: auto; left: 0vh; right: 16vh; width: 8vh; height: 8vh;"
@@ -521,24 +543,6 @@ function insertCanvasElements() {
     document.temp = new logManager();
 	document.temp.init();
 }
-`
-document.documentElement.appendChild(mobileScript);
-// Lazy way to hide touch controls through CSS.
-let inGameStyle = document.createElement("style");
-inGameStyle.id = "inGameStyle";
-inGameStyle.textContent = `
-    .inGame {
-        display: none;
-    }`;
-document.documentElement.appendChild(inGameStyle);
-
-let inMenuStyle = document.createElement("style");
-inMenuStyle.id = "inMenuStyle";
-inMenuStyle.textContent = `
-    .inMenu {
-        display: none;
-    }`;
-document.documentElement.appendChild(inMenuStyle);
 // CSS for touch screen buttons, along with fixing iOS's issues with 100vh ignoring the naviagtion bar, and actually disabling zoom because safari ignores user-scalable=no :(
 let customStyle = document.createElement("style");
 customStyle.textContent = `

--- a/eaglermobile.user.js
+++ b/eaglermobile.user.js
@@ -6,13 +6,14 @@
 // @downloadURL     https://raw.githubusercontent.com/FlamedDogo99/EaglerMobile/main/eaglermobile.user.js
 // @license         Apache License 2.0 - http://www.apache.org/licenses/
 // @match           https://eaglercraft.com/mc/*
-// @version         3.0.3-alpha-5
+// @version         3.0.3
 // @updateURL       https://raw.githubusercontent.com/FlamedDogo99/EaglerMobile/main/eaglermobile.user.js
 // @run-at          document-start
 // @grant           unsafeWindow
 // ==/UserScript==
 
 // This is generally a bad practice, but we need to run scripts in the main context before the DOM loads. Because we are only matching eaglercraft.com, the use of unsafeWindow should be safe to use.
+// If someone knows a better way of doing this, please create an issue
 try {
 	unsafeWindow.console.warn("DANGER: This userscript is  using unsafeWindow. Unsafe websites could potentially use this to gain access to data and other content that the browser normally wouldn't allow!")
     Object.defineProperty(window, "clientWindow", {
@@ -46,27 +47,6 @@ clientWindow.blockNextInput = false;
 var previousTouchX = null;
 var previousTouchY = null;
 var startTouchX = null;
-//TEMP REMOVE
-function logManager() {
-    var self = this;
-
-    self.init = function () {
-        clientWindow.console.log('logmanager initialized');
-        var old = clientWindow.console.log;
-        self.logger = document.getElementById('log');
-        clientWindow.console.log = function (message, options) {
-            if (typeof message == 'object') {
-                self.logger.innerHTML = (JSON && JSON.stringify ? JSON.stringify(message) : message) + '<br />' + self.logger.innerHTML;
-            } else {
-                self.logger.innerHTML = message + '<br />' + self.logger.innerHTML;
-            }
-        }
-    }
-    self.toggleLogVisibility = function () {
-        return $(self.logger).toggle();
-    };
-}
-
 
 // better charCodeAt function
 String.prototype.toKeyCode = function() {
@@ -372,7 +352,7 @@ function insertCanvasElements() {
     crouchButton.addEventListener("touchstart", function(e){
         keyEvent("shift", "keydown")
         clientWindow.crouchLock = clientWindow.crouchLock ? null : false
-        crouchTimer = setTimeout(function(e) {
+        clientWindow.crouchTimer = setTimeout(function(e) {
             clientWindow.crouchLock = (clientWindow.crouchLock != null);
             crouchButton.classList.toggle('active');
         }, 1000);
@@ -384,7 +364,7 @@ function insertCanvasElements() {
             crouchButton.classList.remove('active');
             clientWindow.crouchLock = false
         }
-        clearTimeout(crouchTimer);
+        clearTimeout(clientWindow.crouchTimer);
     }, false);
     document.body.appendChild(crouchButton);
     let inventoryButton = createTouchButton("inventoryButton", "inGame");
@@ -402,10 +382,7 @@ function insertCanvasElements() {
     hiddenInput.id = "hiddenInput"
     hiddenInput.classList.add("inMenu")
     // We are hiding the text input behind button because opacity was causing problems.
-    //TEMP REVERT
-    //hiddenInput.style.cssText = "position:absolute;top: 0vh; margin: auto; left: 8vh; right:0vh; width: 8vh; height: 8vh;font-size:20px;z-index:-10;color: transparent;text-shadow: 0 0 0 black;";
-
-    hiddenInput.style.cssText = "position:absolute;top: 0vh; margin: auto; left: 8vh; right:0vh; width: 8vh; height: 8vh;font-size:20px;z-index:10";
+    hiddenInput.style.cssText = "position:absolute;top: 0vh; margin: auto; left: 8vh; right:0vh; width: 8vh; height: 8vh;font-size:20px;z-index:-10;color: transparent;text-shadow: 0 0 0 black;";
     hiddenInput.value = " " //Allows delete to be detected before input is changed
     hiddenInput.addEventListener("input", function(e) {
         e.stopImmediatePropagation();
@@ -413,9 +390,6 @@ function insertCanvasElements() {
         let inputData = e.data == null ? "delete" : e.data.slice(-1);
         if(!clientWindow.lastKey) { // If we get an event before any keys have been pressed, we know that setting the hiddenInput creates duplicate input events, so we can apply the fix
         	clientWindow.console.warn("Enabling blocking duplicate key events. Some functionality may be lost.")
-        	// TEMP REMOVE
-        	clientWindow.console.log("Enabling blocking duplicate key events. Some functionality may be lost.")
-        	// TEMP
         	clientWindow.inputFix = true;
         }
         clientWindow.console.log(`Received input by ${e.inputType}: ${e.data} -> ${inputData}`);
@@ -451,9 +425,6 @@ function insertCanvasElements() {
     }, false);
     hiddenInput.addEventListener("keydown", function(e) {
         if((e.keyCode == 229 || e.which == 229) && !clientWindow.keyboardFix) {
-        	// TEMP REMOVE
-			clientWindow.console.log("Switching from keydown to input events due to invalid KeyboardEvent. Some functionality will be lost.")
-			// TEMP
         	clientWindow.console.warn("Switching from keydown to input events due to invalid KeyboardEvent. Some functionality will be lost.")
             clientWindow.keyboardFix = true;
             if(clientWindow.lastKey) {
@@ -501,7 +472,7 @@ function insertCanvasElements() {
     sprintButton.addEventListener("touchstart", function(e) {
         keyEvent("r", "keydown");
         clientWindow.sprintLock = clientWindow.sprintLock ? null : false
-        sprintTimer = setTimeout(function(e) {
+        clientWindow.sprintTimer = setTimeout(function(e) {
             clientWindow.sprintLock = (clientWindow.sprintLock != null);
             sprintButton.classList.toggle('active');
         }, 1000);
@@ -513,7 +484,7 @@ function insertCanvasElements() {
             sprintButton.classList.remove('active');
             clientWindow.sprintLock = false
         }
-        clearTimeout(sprintTimer);
+        clearTimeout(clientWindow.sprintTimer);
     }, false);
     document.body.appendChild(sprintButton);
     let pauseButton = createTouchButton("pauseButton", "inGame");
@@ -558,15 +529,6 @@ function insertCanvasElements() {
         keyEvent("3", "keyup");
     }, false);
     document.body.appendChild(coordinatesButton);
-    //TEMP REMOVE
-    var temp = document.createElement("div");
-    temp.id = "log";
-    temp.classList.add("log");
-    temp.style.cssText= "position: absolute; top: 8vh; margin: auto; left: 0vh; right: 0vh; height: auto; z-index:10; min-height:8vh; background:white";
-    temp.innerHtml = "Loading..."
-    document.body.appendChild(temp);
-    document.temp = new logManager();
-	document.temp.init();
 }
 // CSS for touch screen buttons, along with fixing iOS's issues with 100vh ignoring the naviagtion bar, and actually disabling zoom because safari ignores user-scalable=no :(
 let customStyle = document.createElement("style");

--- a/eaglermobile.user.js
+++ b/eaglermobile.user.js
@@ -6,7 +6,7 @@
 // @downloadURL     https://raw.githubusercontent.com/FlamedDogo99/EaglerMobile/main/eaglermobile.user.js
 // @license         Apache License 2.0 - http://www.apache.org/licenses/
 // @match           https://eaglercraft.com/mc/*
-// @version         3.0.3-alpha-4
+// @version         3.0.3-alpha-5
 // @updateURL       https://raw.githubusercontent.com/FlamedDogo99/EaglerMobile/main/eaglermobile.user.js
 // @run-at          document-start
 // @grant           unsafeWindow
@@ -14,11 +14,19 @@
 
 // THIS IS LAZY AND CAN EXPOSE INTERNALS
 // IN THE FUTURE, JUST INJECT A SCRIPT TAG
-
+//try {
+//var window = unsafeWindow ?? window
+//} catch {
+//
+//}
 try {
-window = unsafeWindow ?? window
+	if(unsafeWindow) {
+		console.log("UNSAFE WINDOW RAGGHHH")
+	}
 } catch {
-
+	Object.defineProperty(window, "unsafeWindow", {
+		value: window
+	});
 }
 
 function isMobile() {
@@ -32,10 +40,11 @@ function isMobile() {
 if(!isMobile()) {
     alert("WARNING: This script was created for mobile, and may break functionality in non-mobile browsers!");
 }
-window.keyboardEnabled = false;
-window.crouchLock = false;
-window.sprintLock = false;
-window.keyboardFix = false; // temporarily set to true until I can figure out whats going wrong with the event listener in charge of switching it
+
+unsafeWindow.keyboardEnabled = false;
+unsafeWindow.crouchLock = false;
+unsafeWindow.sprintLock = false;
+unsafeWindow.keyboardFix = false; // temporarily set to true until I can figure out whats going wrong with the event listener in charge of switching it
 // Used for changing touchmove events to mousemove events
 var previousTouchX = null;
 var previousTouchY = null;
@@ -45,10 +54,10 @@ function logManager() {
     var self = this;
 
     self.init = function () {
-        console.log('logmanager initialized');
-        var old = console.log;
+        unsafeWindow.console.log('logmanager initialized');
+        var old = unsafeWindow.console.log;
         self.logger = document.getElementById('log');
-        console.log = function (message, options) {
+        unsafeWindow.console.log = function (message, options) {
             if (typeof message == 'object') {
                 self.logger.innerHTML = (JSON && JSON.stringify ? JSON.stringify(message) : message) + '<br />' + self.logger.innerHTML;
             } else {
@@ -74,7 +83,7 @@ Object.defineProperty(EventTarget.prototype, "addEventListener", {
     value: function (type, fn, ...rest) {
         if(type == 'keydown') {
             _addEventListener.call(this, type, function(...args) {
-                if(!args[0].isValid && window.keyboardFix) {
+                if(!args[0].isValid && unsafeWindow.keyboardFix) {
                     return;
                 }
                 return fn.apply(this, args);
@@ -105,7 +114,7 @@ function keyEvent(name, state) {
         which: charCode
     });
     evt.isValid = true; // Disables fix for bad keyboard input
-    window.dispatchEvent(evt);
+    unsafeWindow.dispatchEvent(evt);
 }
 function mouseEvent(number, state, canvas) {
     canvas.dispatchEvent(new PointerEvent(state, {"button": number}))
@@ -123,11 +132,11 @@ function setButtonVisibility(pointerLocked) {
 }
 // POINTERLOCK
 // When requestpointerlock is called, this dispatches an event, saves the requested element to window.fakelock, and unhides the touch controls
-window.fakelock = null;
+unsafeWindow.fakelock = null;
 
 Object.defineProperty(Element.prototype, "requestPointerLock", {
 	value: function() {
-		window.fakelock = this
+		unsafeWindow.fakelock = this
 		document.dispatchEvent(new Event('pointerlockchange'));
 		setButtonVisibility(true);
 		return true
@@ -138,13 +147,13 @@ Object.defineProperty(Element.prototype, "requestPointerLock", {
 // Makes pointerLockElement return window.fakelock
 Object.defineProperty(Document.prototype, "pointerLockElement", {
     get: function() {
-        return window.fakelock;
+        return unsafeWindow.fakelock;
     }
 });
 // When exitPointerLock is called, this dispatches an event, clears the
 Object.defineProperty(Document.prototype, "exitPointerLock", {
 	value: function() {
-		window.fakelock = null
+		unsafeWindow.fakelock = null
 		document.dispatchEvent(new Event('pointerlockchange'));
 		setButtonVisibility(false);
 		return true
@@ -152,23 +161,23 @@ Object.defineProperty(Document.prototype, "exitPointerLock", {
 });
 
 // FULLSCREEN
-window.fakefull = null;
+unsafeWindow.fakefull = null;
 // Stops the client from crashing when fullscreen is requested
 Object.defineProperty(Element.prototype, "requestFullscreen", {
 	value: function() {
-		window.fakefull = this
+		unsafeWindow.fakefull = this
 		document.dispatchEvent(new Event('fullscreenchange'));
 		return true
 	}
 });
 Object.defineProperty(document, "fullscreenElement", {
     get: function() {
-        return window.fakefull;
+        return unsafeWindow.fakefull;
     }
 });
 Object.defineProperty(Document.prototype, "exitFullscreen", {
 	value: function() {
-		window.fakefull = null
+		unsafeWindow.fakefull = null
 		document.dispatchEvent(new Event('fullscreenchange'));
 		return true
 	}
@@ -188,7 +197,7 @@ document.createElement = function(type, ignore) {
     		element.hidden = true;
     		element.style.display = "none";
     	}, {passive: false, once: true});
-    	window.addEventListener('focus', function(e) {
+    	unsafeWindow.addEventListener('focus', function(e) {
             setTimeout(() => {
                 element.hidden = true;
     			element.style.display = "none";
@@ -246,11 +255,11 @@ function createTouchButton(buttonClass, buttonDisplay, elementName) {
 
 function toggleKeyboard() {
     const keyboardInput = document.getElementById('hiddenInput');
-    if (window.keyboardEnabled) {
-        window.keyboardEnabled = false;
+    if (unsafeWindow.keyboardEnabled) {
+        unsafeWindow.keyboardEnabled = false;
         keyboardInput.blur();
     } else {
-        window.keyboardEnabled = true;
+        unsafeWindow.keyboardEnabled = true;
         keyboardInput.select();
     }
 }
@@ -269,7 +278,7 @@ function insertCanvasElements() {
         }
         e.movementX = touch.pageX - previousTouchX;
         e.movementY = touch.pageY - previousTouchY;
-        var evt = window.fakelock ? new MouseEvent("mousemove", {movementX: e.movementX, movementY: e.movementY}) : new WheelEvent("wheel", {"wheelDeltaY": e.movementY});
+        var evt = unsafeWindow.fakelock ? new MouseEvent("mousemove", {movementX: e.movementX, movementY: e.movementY}) : new WheelEvent("wheel", {"wheelDeltaY": e.movementY});
         canvas.dispatchEvent(evt);
         previousTouchX = touch.pageX;
         previousTouchY = touch.pageY;
@@ -280,7 +289,7 @@ function insertCanvasElements() {
         previousTouchY = null; 
     }, false)
     //Updates button visibility on load
-    setButtonVisibility(window.fakelock != null);
+    setButtonVisibility(unsafeWindow.fakelock != null);
     // Adds all of the touch screen controls
     // Theres probably a better way to do this but this works for now
     let strafeRightButton = createTouchButton("strafeRightButton", "inGame", "div");
@@ -306,13 +315,13 @@ function insertCanvasElements() {
             startTouchX = touch.pageX;
         }
         let movementX = touch.pageX - startTouchX;
-        if((movementX * 10) > window.innerHeight) {
+        if((movementX * 10) > unsafeWindow.innerHeight) {
             strafeRightButton.classList.add("active");
             strafeLeftButton.classList.remove("active");
             keyEvent("d", "keydown");
             keyEvent("a", "keyup");
             
-        } else if ((movementX * 10) < (0 - window.innerHeight)) {
+        } else if ((movementX * 10) < (0 - unsafeWindow.innerHeight)) {
             strafeLeftButton.classList.add("active");
             strafeRightButton.classList.remove("active");
             keyEvent("a", "keydown");
@@ -365,18 +374,18 @@ function insertCanvasElements() {
     crouchButton.style.cssText = "left:10vh;bottom:10vh;"
     crouchButton.addEventListener("touchstart", function(e){
         keyEvent("shift", "keydown")
-        window.crouchLock = window.crouchLock ? null : false
+        unsafeWindow.crouchLock = unsafeWindow.crouchLock ? null : false
         crouchTimer = setTimeout(function(e) {
-            window.crouchLock = (window.crouchLock != null);
+            unsafeWindow.crouchLock = (unsafeWindow.crouchLock != null);
             crouchButton.classList.toggle('active');
         }, 1000);
     }, false);
 
     crouchButton.addEventListener("touchend", function(e) {
-        if(!window.crouchLock) {
+        if(!unsafeWindow.crouchLock) {
             keyEvent("shift", "keyup")
             crouchButton.classList.remove('active');
-            window.crouchLock = false
+            unsafeWindow.crouchLock = false
         }
         clearTimeout(crouchTimer);
     }, false);
@@ -404,11 +413,11 @@ function insertCanvasElements() {
     hiddenInput.addEventListener("input", function(e) {
     	e.preventDefault(true);
         let inputData = e.data == null ? "delete" : e.data.slice(-1);
-        console.log(`Received input by ${e.inputType}: ${e.data} -> ${inputData}`);
+        unsafeWindow.console.log(`Received input by ${e.inputType}: ${e.data} -> ${inputData}`);
 
-        window.lastKey = inputData
+        unsafeWindow.lastKey = inputData
         hiddenInput.value = " "; // We need a character to detect deleting
-        if(window.keyboardFix) {
+        if(unsafeWindow.keyboardFix) {
         	const sliceInputType = e.inputType.slice(0,1); // This is a really dumb way to do this because it's not future-proof
             if(sliceInputType== 'i') {
                 let isShift = (inputData.toLowerCase() != inputData);
@@ -428,12 +437,12 @@ function insertCanvasElements() {
         }
     }, false);
     hiddenInput.addEventListener("keydown", function(e) {
-        if(!(e.key && e.keyCode && e.which) && !window.keyboardFix) {
-        	console.warn("Switching from keydown to input events due to invalid KeyboardEvent. Some functionality will be lost.")
-            window.keyboardFix = true;
-            if(window.lastKey) {
-            	keyEvent(window.lastKey, "keydown");
-            	keyEvent(window.lastKey, "keyup");
+        if(!(e.key && e.keyCode && e.which) && !unsafeWindow.keyboardFix) {
+        	unsafeWindow.console.warn("Switching from keydown to input events due to invalid KeyboardEvent. Some functionality will be lost.")
+            unsafeWindow.keyboardFix = true;
+            if(unsafeWindow.lastKey) {
+            	keyEvent(unsafeWindow.lastKey, "keydown");
+            	keyEvent(unsafeWindow.lastKey, "keyup");
             }
         }
     }, false);
@@ -475,18 +484,18 @@ function insertCanvasElements() {
     sprintButton.style.cssText = "right:0vh;bottom:10vh;"
     sprintButton.addEventListener("touchstart", function(e) {
         keyEvent("r", "keydown");
-        window.sprintLock = window.sprintLock ? null : false
+        unsafeWindow.sprintLock = unsafeWindow.sprintLock ? null : false
         sprintTimer = setTimeout(function(e) {
-            window.sprintLock = (window.sprintLock != null);
+            unsafeWindow.sprintLock = (unsafeWindow.sprintLock != null);
             sprintButton.classList.toggle('active');
         }, 1000);
     }, false);
 
     sprintButton.addEventListener("touchend", function(e) {
-        if(!window.sprintLock) {
+        if(!unsafeWindow.sprintLock) {
             keyEvent("r", "keyup");
             sprintButton.classList.remove('active');
-            window.sprintLock = false
+            unsafeWindow.sprintLock = false
         }
         clearTimeout(sprintTimer);
     }, false);

--- a/eaglermobile.user.js
+++ b/eaglermobile.user.js
@@ -6,12 +6,19 @@
 // @downloadURL     https://raw.githubusercontent.com/FlamedDogo99/EaglerMobile/main/eaglermobile.user.js
 // @license         Apache License 2.0 - http://www.apache.org/licenses/
 // @match           https://eaglercraft.com/mc/*
-// @version         3.0.3-alpha-3
+// @version         3.0.3-alpha-4
 // @updateURL       https://raw.githubusercontent.com/FlamedDogo99/EaglerMobile/main/eaglermobile.user.js
 // @run-at          document-start
 // ==/UserScript==
 
+// THIS IS LAZY AND CAN EXPOSE INTERNALS
+// IN THE FUTURE, JUST INJECT A SCRIPT TAG
 
+try {
+window = unsafeWindow ?? window
+} catch {
+
+}
 function isMobile() {
     try {
         document.createEvent("TouchEvent");
@@ -41,9 +48,9 @@ function logManager() {
         self.logger = document.getElementById('log');
         console.log = function (message, options) {
             if (typeof message == 'object') {
-                self.logger.innerText = (JSON && JSON.stringify ? JSON.stringify(message) : message) + '<br />' + self.logger.innerHTML;
+                self.logger.innerHTML = (JSON && JSON.stringify ? JSON.stringify(message) : message) + '<br />' + self.logger.innerHTML;
             } else {
-                self.logger.innerText = message + " " + self.logger.innerText;
+                self.logger.innerHTML = message + '<br />' + self.logger.innerHTML;
             }
         }
     }
@@ -524,7 +531,7 @@ function insertCanvasElements() {
     }, false);
     document.body.appendChild(coordinatesButton);
     //TEMP REMOVE
-    var temp = document.createElement("p");
+    var temp = document.createElement("div");
     temp.id = "log";
     temp.classList.add("log");
     temp.style.cssText= "position: absolute; top: 8vh; margin: auto; left: 0vh; right: 0vh; height: auto; z-index:10; min-height:8vh; background:white";

--- a/eaglermobile.user.js
+++ b/eaglermobile.user.js
@@ -430,7 +430,7 @@ function insertCanvasElements() {
         }
     }, false);
     hiddenInput.addEventListener("keydown", function(e) {
-        if((e.keyCode = 229 || e.which = 229) && !unsafeWindow.keyboardFix) {
+        if((e.keyCode == 229 || e.which == 229) && !unsafeWindow.keyboardFix) {
         	unsafeWindow.console.warn("Switching from keydown to input events due to invalid KeyboardEvent. Some functionality will be lost.")
             unsafeWindow.keyboardFix = true;
             if(unsafeWindow.lastKey) {

--- a/eaglermobile.user.js
+++ b/eaglermobile.user.js
@@ -16,6 +16,7 @@
 // IN THE FUTURE, JUST INJECT A SCRIPT TAG
 try {
 	unsafeWindow.console.log("UNSAFE WINDOW RAGGHHH")
+	alert("DANGER: This userscript is temporarily using unsafeWindow for testing purposes. Unsafe websites could potentially use this to gain access to data and other content that the browser normally wouldn't allow!")
 } catch {
 	Object.defineProperty(window, "unsafeWindow", {
 		value: window
@@ -404,6 +405,7 @@ function insertCanvasElements() {
     hiddenInput.style.cssText = "position:absolute;top: 0vh; margin: auto; left: 8vh; right:0vh; width: 8vh; height: 8vh;font-size:20px;z-index:10";
     hiddenInput.value = " " //Allows delete to be detected before input is changed
     hiddenInput.addEventListener("input", function(e) {
+        e.stopImmediatePropagation();
     	e.preventDefault(true);
         let inputData = e.data == null ? "delete" : e.data.slice(-1);
         unsafeWindow.console.log(`Received input by ${e.inputType}: ${e.data} -> ${inputData}`);

--- a/eaglermobile.user.js
+++ b/eaglermobile.user.js
@@ -61,7 +61,7 @@ function logManager() {
 
 // better charCodeAt function
 String.prototype.toKeyCode = function() {
-    const keyCodeList = {"0": 48, "1": 49, "2": 50, "3": 51, "4": 52, "5": 53, "6": 54, "7": 55, "8": 56, "9": 57, "backspace": 8, "tab": 9, "enter": 13, "shift": 16, "ctrl": 17, "alt": 18, "pause_break": 19, "caps_lock": 20, "escape": 27, " ": 32, "page_up": 33, "page_down": 34, "end": 35, "home": 36, "left_arrow": 37, "up_arrow": 38, "right_arrow": 39, "down_arrow": 40, "insert": 45, "delete": 46, "a": 65, "b": 66, "c": 67, "d": 68, "e": 69, "f": 70, "g": 71, "h": 72, "i": 73, "j": 74, "k": 75, "l": 76, "m": 77, "n": 78, "o": 79, "p": 80, "q": 81, "r": 82, "s": 83, "t": 84, "u": 85, "v": 86, "w": 87, "x": 88, "y": 89, "z": 90, "left_window_key": 91, "right_window_key": 92, "select_key": 93, "numpad_0": 96, "numpad_1": 97, "numpad_2": 98, "numpad_3": 99, "numpad_4": 100, "numpad_5": 101, "numpad_6": 102, "numpad_7": 103, "numpad_8": 104, "numpad_9": 105, "*": 106, "+": 107, "-": 109, ".": 110, "/": 111, "f1": 112, "f2": 113, "f3": 114, "f4": 115, "f5": 116, "f6": 117, "f7": 118, "f8": 119, "f9": 120, "f10": 121, "f11": 122, "f12": 123, "num_lock": 144, "scroll_lock": 145, ";": 186, "=": 187, ",": 188, "-": 189, ".": 190, "/": 191, "\`": 192, "[": 219, "\\": 220, "]": 221, "\"": 222};
+    const keyCodeList = {"0": 48, "1": 49, "2": 50, "3": 51, "4": 52, "5": 53, "6": 54, "7": 55, "8": 56, "9": 57, "backspace": 8, "tab": 9, "enter": 13, "shift": 16, "ctrl": 17, "alt": 18, "pause_break": 19, "caps_lock": 20, "escape": 27, " ": 32, "page_up": 33, "page_down": 34, "end": 35, "home": 36, "left_arrow": 37, "up_arrow": 38, "right_arrow": 39, "down_arrow": 40, "insert": 45, "delete": 46, "a": 65, "b": 66, "c": 67, "d": 68, "e": 69, "f": 70, "g": 71, "h": 72, "i": 73, "j": 74, "k": 75, "l": 76, "m": 77, "n": 78, "o": 79, "p": 80, "q": 81, "r": 82, "s": 83, "t": 84, "u": 85, "v": 86, "w": 87, "x": 88, "y": 89, "z": 90, "left_window_key": 91, "right_window_key": 92, "select_key": 93, "numpad_0": 96, "numpad_1": 97, "numpad_2": 98, "numpad_3": 99, "numpad_4": 100, "numpad_5": 101, "numpad_6": 102, "numpad_7": 103, "numpad_8": 104, "numpad_9": 105, "*": 106, "+": 107, "-": 109, ".": 110, "/": 111, "f1": 112, "f2": 113, "f3": 114, "f4": 115, "f5": 116, "f6": 117, "f7": 118, "f8": 119, "f9": 120, "f10": 121, "f11": 122, "f12": 123, "num_lock": 144, "scroll_lock": 145, ";": 186, "=": 187, ",": 188, "-": 189, ".": 190, "/": 191, "\`": 192, "[": 219, "\\\": 220, "]": 221, "\\"": 222};
     return keyCodeList[this];
 }
 // Ignores keydown events that don't have the isValid parameter set to true
@@ -382,7 +382,7 @@ function insertCanvasElements() {
     hiddenInput.addEventListener("input", function(e) {
     	e.preventDefault(true);
         let inputData = e.data == null ? "delete" : e.data.slice(-1);
-        console.log(\`Received input by ${e.inputType}: ${e.data} -> ${inputData}\`);
+        console.log("Received input by " + e.inputType + ": " + e.data + " -> " + inputData);
 
         window.lastKey = inputData
         hiddenInput.value = " "; // We need a character to detect deleting
@@ -522,7 +522,7 @@ function insertCanvasElements() {
 	document.temp.init();
 }
 `
-document.documentElement.appendChild(mobileScript)
+document.documentElement.appendChild(mobileScript);
 // Lazy way to hide touch controls through CSS.
 let inGameStyle = document.createElement("style");
 inGameStyle.id = "inGameStyle";


### PR DESCRIPTION
<!-- Which issue(s) does this pull request fix or resolve? If there aren't any, please submit one first unless this is a hotfix or minor string update. -->

Possibly resolves #15 and #7 

### Changes

1. All calls to `window` are now `clientWindow`
2. Added `inputFix` window state, which is turned on when double input events are detected
3. Added CSS and eventListener to prevent long presses on Chrome triggering the save-image dialog 

### Reason for changes

1. Tampermonkey does not allow Userscripts to run outside of the sandbox, while the iOS Userscripts app does. This change allows the `window` object to be used when unsafeWindow is undefined.
2. Some Android devices dispatch an additional `input` event when the input element is programmatically updated. When we set the input for the first time as the DOM loads, we can see if this is happening. If it is, we ignore every other duplicate key press.
3. To use the touch controls, the user is required to hold or drag on buttons. On iOS Chrome, this causes the save-image dialog to appear. This change should prevent that.
### Tests
  - MacOS Brave with Tampermonkey
  - MacOS Safari with Userscripts
  - MacOS Brave through script tag
  - MacOS Safari through script tag
  - Pixel 8 Pro API 29 through Android Studio, running Android 10.0 ("Q"), arm64 on FireFox with Tampermonkey
  - iOS Safari with Userscripts
  - iOS Orion with Tampermonkey
